### PR TITLE
Support reconnect on error (unbind w/o close)

### DIFF
--- a/lib/em-redis/redis_protocol.rb
+++ b/lib/em-redis/redis_protocol.rb
@@ -337,12 +337,13 @@ module EventMachine
       end
 
       def initialize(options = {})
-        @host           = options[:host]
-        @port           = options[:port]
-        @db             = (options[:db] || 0).to_i
-        @password       = options[:password]
-        @auto_reconnect = options[:auto_reconnect] || true
-        @logger         = options[:logger]
+        @host               = options[:host]
+        @port               = options[:port]
+        @db                 = (options[:db] || 0).to_i
+        @password           = options[:password]
+        @auto_reconnect     = options.fetch(:auto_reconnect, true)
+        @reconnect_on_error = options.fetch(:reconnect_on_error, false)
+        @logger             = options[:logger]
         @error_callback = lambda do |err|
           raise err
         end
@@ -486,7 +487,7 @@ module EventMachine
         @logger.debug { "Disconnected" } if @logger
         if @closing
           @reconnecting = false
-        elsif (@connected || @reconnecting) && @auto_reconnect
+        elsif ((@connected || @reconnecting) && @auto_reconnect) || @reconnect_on_error
           @reconnect_callbacks[:before].call if @connected
           @reconnecting = true
           EM.add_timer(1) do

--- a/lib/em-redis/redis_protocol.rb
+++ b/lib/em-redis/redis_protocol.rb
@@ -488,7 +488,7 @@ module EventMachine
         if @closing
           @reconnecting = false
         elsif ((@connected || @reconnecting) && @auto_reconnect) || @reconnect_on_error
-          @reconnect_callbacks[:before].call if @connected
+          @reconnect_callbacks[:before].call unless @reconnecting
           @reconnecting = true
           EM.add_timer(1) do
             @logger.debug { "Reconnecting to #{@host}:#{@port}" } if @logger


### PR DESCRIPTION
This  PR adds support for the `reconnect_on_error` connection option. Setting `reconnect_on_error` to true will cause unbind() to trigger a reconnect in the event of a failure. This PR also fixes the `auto_reconnect` option default value, it was forced to always be true.
