### PR TITLE
Redis pubsub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 pkg
+*.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 pkg
 *.lock
+*.gem

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gemspec

--- a/em-redis-unified.gemspec
+++ b/em-redis-unified.gemspec
@@ -1,0 +1,27 @@
+# coding: utf-8
+$:.unshift File.expand_path("../lib", __FILE__)
+require "em-redis"
+
+Gem::Specification.new do |spec|
+  spec.name          = "em-redis-unified"
+  spec.version       = EMRedis::VERSION
+  spec.authors       = ["Jonathan Broad", "Eugene Pimenov", "Sean Porter"]
+  spec.email         = ["portertech@gmail.com"]
+  spec.summary       = "An eventmachine-based implementation of the Redis protocol"
+  spec.description   = "An eventmachine-based implementation of the Redis protocol"
+  spec.homepage      = "https://github.com/portertech/em-redis"
+  spec.license       = "MIT"
+
+  spec.files         = `git ls-files -z`.split("\x0")
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.add_dependency("eventmachine", ">=0.12.10")
+
+  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
+  spec.add_development_dependency "em-spec"
+  spec.add_development_dependency "bacon"
+end

--- a/em-redis-unified.gemspec
+++ b/em-redis-unified.gemspec
@@ -1,6 +1,6 @@
 # coding: utf-8
 $:.unshift File.expand_path("../lib", __FILE__)
-require "em-redis"
+require "em-redis/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "em-redis-unified"
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency("eventmachine", ">=0.12.10")
+  spec.add_dependency("eventmachine", ">= 0.12.10")
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/em-redis-unified.rb
+++ b/lib/em-redis-unified.rb
@@ -1,0 +1,1 @@
+require "em-redis"

--- a/lib/em-redis.rb
+++ b/lib/em-redis.rb
@@ -1,4 +1,4 @@
-require 'em-redis/version'
+require File.join(File.dirname(__FILE__), 'em-redis/version')
 
 module EMRedis
   LIBPATH = ::File.expand_path(::File.dirname(__FILE__)) + ::File::SEPARATOR

--- a/lib/em-redis.rb
+++ b/lib/em-redis.rb
@@ -1,8 +1,6 @@
+require 'em-redis/version'
 
 module EMRedis
-
-  # :stopdoc:
-  VERSION = '0.6.0'
   LIBPATH = ::File.expand_path(::File.dirname(__FILE__)) + ::File::SEPARATOR
   PATH = ::File.dirname(LIBPATH) + ::File::SEPARATOR
   # :startdoc:

--- a/lib/em-redis/redis_protocol.rb
+++ b/lib/em-redis/redis_protocol.rb
@@ -232,10 +232,6 @@ module EventMachine
         @error_callback.call(err)
       end
 
-      def on_connect(&blk)
-        @on_connect_callback = blk
-      end
-
       def before_reconnect(&blk)
         @reconnect_callbacks[:before] = blk
       end
@@ -371,7 +367,6 @@ module EventMachine
         @error_callback = lambda do |err|
           raise err
         end
-        @on_connect_callback = lambda{}
         @reconnect_callbacks = {
           :before => lambda{},
           :after  => lambda{}
@@ -393,11 +388,10 @@ module EventMachine
         @logger.debug { "Connected to #{@host}:#{@port}" } if @logger
         @redis_callbacks = []
         @multibulk_n     = false
+        @connected       = true
         auth_and_select_db
         @reconnect_callbacks[:after].call if @reconnecting
-        @on_connect_callback.call
         @reconnecting = false
-        @connected    = true
         succeed
       end
 

--- a/lib/em-redis/redis_protocol.rb
+++ b/lib/em-redis/redis_protocol.rb
@@ -201,8 +201,8 @@ module EventMachine
         @subscribe_callbacks ||= Hash.new([])
         argv = ["unsubscribe"]
         if channel
-          argv << channel
           @subscribe_callbacks[channel] = [blk]
+          argv << channel
         else
           @subscribe_callbacks.each_key do |key|
             @subscribe_callbacks[key] = [blk]

--- a/lib/em-redis/redis_protocol.rb
+++ b/lib/em-redis/redis_protocol.rb
@@ -507,6 +507,10 @@ module EventMachine
         @connected || false
       end
 
+      def reconnect!
+        reconnect(@host, @port)
+      end
+
       def close
         @closing = true
         close_connection_after_writing
@@ -521,7 +525,7 @@ module EventMachine
           @reconnecting = true
           EM.add_timer(1) do
             @logger.debug { "Reconnecting to #{@host}:#{@port}" } if @logger
-            reconnect @host, @port
+            reconnect!
           end
         elsif @connected
           error ConnectionError, 'connection closed'

--- a/lib/em-redis/redis_protocol.rb
+++ b/lib/em-redis/redis_protocol.rb
@@ -474,7 +474,7 @@ module EventMachine
         if @subscribe_callbacks && value.is_a?(Array)
           if %w[message unsubscribe].include?(value[0])
             @subscribe_callbacks[value[1]].each do |blk|
-              blk.call(*value)
+              blk.call(*value) if blk
             end
             return
           end

--- a/lib/em-redis/redis_protocol.rb
+++ b/lib/em-redis/redis_protocol.rb
@@ -232,6 +232,10 @@ module EventMachine
         @error_callback.call(err)
       end
 
+      def auto_reconnect(enabled)
+        @auto_reconnect = !!enabled
+      end
+
       def before_reconnect(&blk)
         @reconnect_callbacks[:before] = blk
       end

--- a/lib/em-redis/redis_protocol.rb
+++ b/lib/em-redis/redis_protocol.rb
@@ -7,6 +7,8 @@ module EventMachine
     module Redis
       include EM::Deferrable
 
+      attr_accessor :auto_reconnect, :reconnect_on_error
+
       ##
       # constants
       #########################
@@ -321,8 +323,6 @@ module EventMachine
       #########################
 
       class << self
-        attr_accessor :auto_reconnect, :reconnect_on_error
-
         def parse_url(url)
           begin
             uri = URI.parse(url)

--- a/lib/em-redis/redis_protocol.rb
+++ b/lib/em-redis/redis_protocol.rb
@@ -232,10 +232,6 @@ module EventMachine
         @error_callback.call(err)
       end
 
-      def auto_reconnect(enabled)
-        @auto_reconnect = !!enabled
-      end
-
       def before_reconnect(&blk)
         @reconnect_callbacks[:before] = blk
       end
@@ -325,6 +321,8 @@ module EventMachine
       #########################
 
       class << self
+        attr_accessor :auto_reconnect, :reconnect_on_error
+
         def parse_url(url)
           begin
             uri = URI.parse(url)

--- a/lib/em-redis/version.rb
+++ b/lib/em-redis/version.rb
@@ -1,0 +1,4 @@
+module EMRedis
+  # :stopdoc:
+  VERSION = '0.6.0'
+end

--- a/spec/live_redis_pubsub_spec.rb
+++ b/spec/live_redis_pubsub_spec.rb
@@ -1,0 +1,51 @@
+require File.expand_path(File.dirname(__FILE__) + "/test_helper.rb")
+
+EM.describe EM::Protocols::Redis, "connected to an empty db" do
+
+  before do
+    @s = EM::Protocols::Redis.connect(:db => 14)
+    @p = EM::Protocols::Redis.connect(:db => 14)
+  end
+
+  should "be able to publish a message to a channel" do
+    @p.flushdb do
+     @p.publish("foo", "test") do |r|
+        r.should == 0
+        done
+      end
+    end
+  end
+
+  should "be able to subscribe to a channel and then unsubscribe" do
+    @s.flushdb do
+      @s.subscribe("foo", Proc.new {}) do |type, channel, subscribers|
+        type.should == "subscribe"
+        channel.should == "foo"
+        subscribers.should == 1
+        @s.unsubscribe do
+          done
+        end
+      end
+    end
+  end
+
+  should "be able to subscribe to a channel and publish a message to it" do
+    @s.flushdb do
+      callback = Proc.new do |type, channel, message|
+        type.should == "message"
+        channel.should == "foo"
+        message.should == "test"
+        done
+      end
+      @s.subscribe("foo", callback) do |type, channel, subscribers|
+        type.should == "subscribe"
+        channel.should == "foo"
+        subscribers.should == 1
+        @p.publish("foo", "test") do |r|
+          r.should == 1
+        end
+      end
+    end
+  end
+
+end

--- a/spec/live_redis_pubsub_spec.rb
+++ b/spec/live_redis_pubsub_spec.rb
@@ -47,5 +47,4 @@ EM.describe EM::Protocols::Redis, "connected to an empty db" do
       end
     end
   end
-
 end


### PR DESCRIPTION
http://redis.io/topics/pubsub

These changes add support for subscribing to a Redis channel. A single Redis connection can subscribe to multiple channels, but cannot use Redis commands outside of the subscribe context. This PR does not add support for patterns, as its making as few changes as possible to enable https://github.com/sensu/sensu-transport/pull/12. Subscribe callbacks shortcut command result dispatching.

![687](https://cloud.githubusercontent.com/assets/149630/7671900/0e43761e-fc96-11e4-86e9-2cc28293ce17.gif)
